### PR TITLE
Prevent scrolling to top on formatting

### DIFF
--- a/lib/inkdrop-prettier.js
+++ b/lib/inkdrop-prettier.js
@@ -2,6 +2,7 @@
 
 import { CompositeDisposable } from "event-kit";
 import prettier from "prettier";
+import { actions } from 'inkdrop';
 
 const pos2offset = (text, pos) => {
   const list = text.split("\n");
@@ -50,6 +51,8 @@ const format = () => {
   const pos = offset2pos(formatted, cursorOffset);
 
   cm.setValue(formatted);
+  inkdrop.store.dispatch(actions.editingNote.update({ body: formatted }))
+  inkdrop.store.dispatch(actions.editor.change(true))
   cm.setCursor(pos);
 
   const afterCoords = cm.cursorCoords();


### PR DESCRIPTION
Hi, thanks for creating this plugin!

I found an issue that the cursor position moves to the top on formatting.
That's because Inkdrop tries to update the editor again when detecting the CodeMirror's state change to maintain its internal state consistency.
So, you have to update not only CodeMirror but also the internal state.
This PR should fix the issue.
